### PR TITLE
added new logic to color patches example

### DIFF
--- a/examples/color_patches/color_patches/model.py
+++ b/examples/color_patches/color_patches/model.py
@@ -23,6 +23,7 @@ class ColorCell(mesa.Agent):
         self._col = pos[1]
         self._state = initial_state
         self._next_state = None
+        # is this agent a cultist property
         self._is_cult_leader = False
 
     def get_col(self):
@@ -37,6 +38,7 @@ class ColorCell(mesa.Agent):
         """Return the current state (OPINION) of this cell."""
         return self._state
 
+    # getter for cultist status
     def get_is_cult_leader(self):
         return self._is_cult_leader
 
@@ -49,6 +51,7 @@ class ColorCell(mesa.Agent):
         """
         _cultist_influence = 4
         _neighbor_iter = self.model.grid.iter_neighbors((self._row, self._col), True)
+        # iterator around neighbors to find nearest cultist
         _check_cultist_iter = self.model.grid.iter_neighbors((self._row, self._col), False, radius=_cultist_influence)
         neighbors_opinion = Counter(n.get_state() for n in _neighbor_iter)
         # Following is a a tuple (attribute, occurrences)
@@ -61,6 +64,7 @@ class ColorCell(mesa.Agent):
             if neighbor[1] == polled_opinions[-1][1]:
                 low_tied_opinions.append(neighbor)
 
+        # logic of retrieving closest cultist's opinion if one is nearby
         cult_leader_opinion = None
         dist = 10000
         for neighbor in _check_cultist_iter:
@@ -70,7 +74,7 @@ class ColorCell(mesa.Agent):
                 if new_dist < dist:
                     dist = new_dist
                 cult_leader_opinion = neighbor.get_state()
-
+        # setting opinion based on distance from cultist
         if cult_leader_opinion and random.random() < (0.9 - dist * 0.2):
             self._next_state = cult_leader_opinion
         elif random.random() < 0.1:
@@ -126,6 +130,7 @@ class ColorPatches(mesa.Model):
         if self._steps % 100 == 0:
             self.manipulate_random_cell()
 
+    # function to get random cell and convert it to cultist
     def manipulate_random_cell(self):
         """
         Selects a random cell in the grid and manipulates it by changing its opinion.
@@ -135,7 +140,6 @@ class ColorPatches(mesa.Model):
 
         # Extract the coordinates from the random position tuple
         row, col = random_position[1]
-        print(random_position)
 
         # Get the agent at the selected random position
         agent = self.grid.get_cell_list_contents([(row, col)])[0]

--- a/examples/color_patches/color_patches/model.py
+++ b/examples/color_patches/color_patches/model.py
@@ -1,7 +1,7 @@
 """
 The model - a 2D lattice where agents live and have an opinion
 """
-
+import random
 from collections import Counter
 
 import mesa
@@ -12,17 +12,18 @@ class ColorCell(mesa.Agent):
     Represents a cell's opinion (visualized by a color)
     """
 
-    OPINIONS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+    OPINIONS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
 
-    def __init__(self, pos, model, initial_state):
+    def __init__(self, pos, unique_id, model, initial_state):
         """
         Create a cell, in the given state, at the given row, col position.
         """
-        super().__init__(model)
+        super().__init__(unique_id, model)
         self._row = pos[0]
         self._col = pos[1]
         self._state = initial_state
         self._next_state = None
+        self._is_cult_leader = False
 
     def get_col(self):
         """Return the col location of this cell."""
@@ -36,6 +37,9 @@ class ColorCell(mesa.Agent):
         """Return the current state (OPINION) of this cell."""
         return self._state
 
+    def get_is_cult_leader(self):
+        return self._is_cult_leader
+
     def determine_opinion(self):
         """
         Determines the agent opinion for the next step by polling its neighbors
@@ -43,22 +47,43 @@ class ColorCell(mesa.Agent):
         A choice is made at random in case of a tie
         The next state is stored until all cells have been polled
         """
+        _cultist_influence = 4
         _neighbor_iter = self.model.grid.iter_neighbors((self._row, self._col), True)
+        _check_cultist_iter = self.model.grid.iter_neighbors((self._row, self._col), False, radius=_cultist_influence)
         neighbors_opinion = Counter(n.get_state() for n in _neighbor_iter)
         # Following is a a tuple (attribute, occurrences)
         polled_opinions = neighbors_opinion.most_common()
         tied_opinions = []
+        low_tied_opinions = []
         for neighbor in polled_opinions:
             if neighbor[1] == polled_opinions[0][1]:
                 tied_opinions.append(neighbor)
+            if neighbor[1] == polled_opinions[-1][1]:
+                low_tied_opinions.append(neighbor)
 
-        self._next_state = self.random.choice(tied_opinions)[0]
+        cult_leader_opinion = None
+        dist = 10000
+        for neighbor in _check_cultist_iter:
+            if neighbor.get_is_cult_leader():
+                new_dist = abs(self._row - neighbor.get_row()) + abs(
+                    self._col - neighbor.get_col())  # Manhattan distance
+                if new_dist < dist:
+                    dist = new_dist
+                cult_leader_opinion = neighbor.get_state()
+
+        if cult_leader_opinion and random.random() < (0.9 - dist * 0.2):
+            self._next_state = cult_leader_opinion
+        elif random.random() < 0.1:
+            self._next_state = self.random.choice(low_tied_opinions)[0]
+        else:
+            self._next_state = self.random.choice(tied_opinions)[0]
 
     def assume_opinion(self):
         """
         Set the state of the agent to the next state
         """
-        self._state = self._next_state
+        if not self._is_cult_leader:
+            self._state = self._next_state
 
 
 class ColorPatches(mesa.Model):
@@ -81,10 +106,11 @@ class ColorPatches(mesa.Model):
         # replaced content with _ to appease linter
         for _, (row, col) in self._grid.coord_iter():
             cell = ColorCell(
-                (row, col), self, ColorCell.OPINIONS[self.random.randrange(0, 16)]
+                (row, col), row + col * row, self, ColorCell.OPINIONS[self.random.randrange(0, 16)]
             )
             self._grid.place_agent(cell, (row, col))
 
+        self.step()
         self.running = True
 
     def step(self):
@@ -95,6 +121,31 @@ class ColorPatches(mesa.Model):
         """
         self.agents.do("determine_opinion")
         self.agents.do("assume_opinion")
+        self._steps += 1
+
+        if self._steps % 100 == 0:
+            self.manipulate_random_cell()
+
+    def manipulate_random_cell(self):
+        """
+        Selects a random cell in the grid and manipulates it by changing its opinion.
+        """
+        # Get a random (row, col) position from the grid
+        random_position = self.random.choice(list(self.grid.coord_iter()))
+
+        # Extract the coordinates from the random position tuple
+        row, col = random_position[1]
+        print(random_position)
+
+        # Get the agent at the selected random position
+        agent = self.grid.get_cell_list_contents([(row, col)])[0]
+
+        # Manipulate the agent - change its opinion to a random new one
+        new_opinion = ColorCell.OPINIONS[-1]
+        agent._state = new_opinion
+        agent._is_cult_leader = True
+
+        print(f"Random cell at ({row}, {col}) changed its opinion to {new_opinion}")
 
     @property
     def grid(self):

--- a/examples/color_patches/color_patches/server.py
+++ b/examples/color_patches/color_patches/server.py
@@ -26,6 +26,7 @@ _COLORS = [
     "Teal",
     "White",
     "Yellow",
+    "Black"
 ]
 
 


### PR DESCRIPTION
two changes were introduced
1. there is now 10% chance for agent to make its mind based on the lowest number of opinions around it. That removes situation where simulation will stop eventually due to created cycles. An example of wall created between two agents which won't change, since every agent near the wall always has bigger number of opinions of its kind.
2. added cultist event which happens every 100 steps. Cultist is placed randomly in grid. He cannot change its opinion and affects other agents based on its influence area. He will eventually take over the grid.